### PR TITLE
Make IGDB game screenshots hidpi compatible

### DIFF
--- a/app/components/GameCard.jsx
+++ b/app/components/GameCard.jsx
@@ -36,7 +36,17 @@ const GameCard = forwardRef(
     const bgColorHover = useColorModeValue('gray.100', 'gray.700');
     const overlayBgColor = useColorModeValue('#ffffffbb', '#00000088');
 
-    const image = images[0]?.thumbnail_url || igdb_game?.screenshots[0]?.url?.replace(/t_thumb/, 't_cover_big');
+    let image = images[0]?.thumbnail_url;
+    let imageSrcSet = images[0]?.thumbnail_url;
+
+    const imageFromIGDB = igdb_game?.screenshots[0]?.url;
+    if (imageFromIGDB) {
+      image = imageFromIGDB.replace(/t_thumb/, 't_cover_big');
+      imageSrcSet = `${image}, ${imageFromIGDB.replace(
+        /t_thumb/,
+        't_cover_big_2x'
+      )} 2x`;
+    }
 
     if (isCompact) {
       return (
@@ -61,6 +71,7 @@ const GameCard = forwardRef(
                 rounded="md"
                 size="100%"
                 src={image}
+                srcSet={imageSrcSet}
                 alt=""
                 zIndex={-1}
               />
@@ -116,6 +127,7 @@ const GameCard = forwardRef(
             size="100%"
             objectFit="cover"
             src={image}
+            srcSet={imageSrcSet}
             alt="Game cover"
             fallbackSrc={placeholder}
             rounded="md"


### PR DESCRIPTION
Using a 4K screen

Before
![image](https://github.com/user-attachments/assets/9de40d6d-1227-4324-96e3-5b8955781139)
After
![image](https://github.com/user-attachments/assets/fd85a7cd-2bbb-46e1-8c6d-f335ca59d298)

Just with this line, nothing changes for others
```diff
 <img alt="Game cover" class="chakra-image css-b85nkz"
  src="//images.igdb.com/igdb/image/upload/t_cover_big/scnylm.jpg"
+ srcset="//images.igdb.com/igdb/image/upload/t_cover_big/scnylm.jpg, //images.igdb.com/igdb/image/upload/t_cover_big_2x/scnylm.jpg 2x"
 >
```