### PR TITLE
Fix missing import in games.delete action

### DIFF
--- a/app/routes/event.$id/games.delete.jsx
+++ b/app/routes/event.$id/games.delete.jsx
@@ -1,6 +1,7 @@
 import { redirect } from "@remix-run/node";
 
 import { db } from "../../utils/db.server";
+import { authorizer, canWrite } from "../../utils/auth.server";
 
 export async function action(args) {
   const { params, request } = args;


### PR DESCRIPTION
## Summary
- add missing authorization imports in `games.delete` route

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684074f69efc83308ab767d0c0c43c1e