### PR TITLE
Add Discord notifications for new items

### DIFF
--- a/app/routes/games.create.jsx
+++ b/app/routes/games.create.jsx
@@ -5,7 +5,11 @@ import { useEffect } from 'react';
 
 import { db } from '../utils/db.server';
 import { authenticator, authorizer, canWrite } from '../utils/auth.server';
+import { notifyDiscord } from '../utils/discordNotification.server';
 import GameForm from '../components/GameForm';
+
+const port = process.env.PORT ?? 3000;
+const BASE_URL = process.env.BASE_URL ?? `http://localhost:${port}`;
 
 export async function action(args) {
   const { request } = args;
@@ -63,6 +67,9 @@ export async function action(args) {
         },
       }),
     ]);
+    await notifyDiscord(
+      `${currentUser.username} added game "${data.get('name')}" at ${new Date().toISOString()} - ${BASE_URL}/game/${game.id}`
+    );
 
     return redirect(`/game/${game.id}`);
   } catch (err) {

--- a/app/utils/discordNotification.server.js
+++ b/app/utils/discordNotification.server.js
@@ -1,0 +1,19 @@
+export async function notifyDiscord(content) {
+  const webhookUrl = process.env.DISCORD_NOTIFICATION_WEBHOOK;
+  if (!webhookUrl) {
+    console.warn('DISCORD_NOTIFICATION_WEBHOOK is not configured');
+    return;
+  }
+
+  try {
+    await fetch(webhookUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ content }),
+    });
+  } catch (err) {
+    console.error('Failed to send Discord notification', err);
+  }
+}


### PR DESCRIPTION
## Summary
- send Discord notifications when new games are created
- send Discord notifications when new events are created
- send Discord notifications when new studios or associations are created
- add helper for sending messages to Discord webhook

## Testing
- `npm run build` *(fails: remix not found)*

------
https://chatgpt.com/codex/tasks/task_e_68581e2b02d88330a7ecf748a8a72ac4