### PR TITLE
Improve tag schema

### DIFF
--- a/prisma/migrations/20250629173557_tag_relation/migration.sql
+++ b/prisma/migrations/20250629173557_tag_relation/migration.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "game" DROP COLUMN IF EXISTS "tag_list";
+ALTER TABLE "game_change" DROP COLUMN IF EXISTS "tag_list";
+ALTER TABLE "tag" ADD COLUMN "description" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -94,7 +94,6 @@ model game {
   name        String
   about       String?
   site        String?
-  tag_list    String[]      @db.VarChar(30)
   created_at  DateTime?     @default(now()) @db.Timestamptz(6)
   updated_at  DateTime?     @updatedAt
   igdb_slug   String?       @unique
@@ -114,7 +113,6 @@ model game_change {
   about      String?
   igdb_slug  String?
   site       String?
-  tag_list   String[]       @db.VarChar(30)
   created_at DateTime?      @default(now()) @db.Timestamptz(6)
   game_id    String         @db.Uuid
   author_id  String?        @db.Uuid
@@ -240,6 +238,7 @@ model reset_token {
 model tag {
   id         String     @id @default(dbgenerated("public.uuid_generate_v4()")) @db.Uuid
   name       String     @unique @db.VarChar(30)
+  description String?
   created_at DateTime?  @default(now()) @db.Timestamptz(6)
   updated_at DateTime?  @updatedAt
   game_tag   game_tag[]


### PR DESCRIPTION
## Summary
- update Prisma schema to remove `tag_list`
- add optional tag descriptions
- generate migration for dropping old columns and adding description field

## Testing
- `npm run build` *(fails: remix not found)*
- `npx prisma migrate dev --name tag-relation --create-only` *(fails: no internet access)*


------
https://chatgpt.com/codex/tasks/task_e_684d93ec61e083308f81fd93471dbb76