### PR TITLE
Implement modal search

### DIFF
--- a/app/components/SearchInput.jsx
+++ b/app/components/SearchInput.jsx
@@ -1,81 +1,25 @@
-import {
-  IconButton,
-  InputGroup,
-  InputLeftElement,
-  InputRightElement,
-  Input,
-  useColorModeValue,
-} from '@chakra-ui/react';
-import { SmallCloseIcon, SearchIcon } from '@chakra-ui/icons';
-import { Form, useLocation, useNavigate } from '@remix-run/react';
-import React, { useRef } from 'react';
-import { useDebouncedCallback } from 'use-debounce';
+import { IconButton, useDisclosure } from '@chakra-ui/react';
+import { SearchIcon } from '@chakra-ui/icons';
+import PropTypes from 'prop-types';
+import SearchModal from './SearchModal';
 
 const propTypes = {};
 
 const defaultProps = {};
 
 const SearchInput = () => {
-  const inputRef = useRef();
-  const navigate = useNavigate();
-  const { pathname, search, state } = useLocation();
-
-  const params = new URLSearchParams(search);
-
-  const handleChange = useDebouncedCallback((value) => {
-    if (value !== '') {
-      params.set('q', value);
-      if (state?.prev || pathname.includes('search')) {
-        // we have a previous page or we're already on search
-        navigate(`search?${params.toString()}`, { replace: true, state });
-      } else {
-        // we're on a page, and we go to search, keeping the page in memory
-        navigate(`search?${params.toString()}`, {
-          state: {
-            prev: pathname,
-          },
-        });
-      }
-    } else {
-      // we have an empty search, we go back to the previous page or home
-      navigate(state?.prev || '/', { replace: true });
-      inputRef.current.value = '';
-    }
-  }, 300);
+  const { isOpen, onOpen, onClose } = useDisclosure();
 
   return (
-    <Form
-      action="/search"
-      method="get"
-      onSubmit={(e) => {
-        if (e.target.q.value === '') e.preventDefault();
-      }}
-    >
-      <InputGroup w="auto" size="lg">
-        <InputLeftElement>
-          <SearchIcon color="teal.500" />
-        </InputLeftElement>
-        <Input
-          ref={inputRef}
-          name="q"
-          placeholder="Search"
-          defaultValue={params.get('q')}
-          autoFocus={pathname === '/search'}
-          bg={useColorModeValue("white", "gray.750")}
-          onChange={(e) => handleChange(e.target.value)}
-        />
-        {params.has('q') && (
-          <InputRightElement>
-            <IconButton
-              aria-label="Clear search"
-              variant="ghost"
-              icon={<SmallCloseIcon />}
-              onClick={() => handleChange('')}
-            />
-          </InputRightElement>
-        )}
-      </InputGroup>
-    </Form>
+    <>
+      <IconButton
+        aria-label="Open search"
+        variant="ghost"
+        icon={<SearchIcon />}
+        onClick={onOpen}
+      />
+      <SearchModal isOpen={isOpen} onClose={onClose} />
+    </>
   );
 };
 

--- a/app/components/SearchModal.jsx
+++ b/app/components/SearchModal.jsx
@@ -1,0 +1,144 @@
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalCloseButton,
+  ModalBody,
+  List,
+  ListItem,
+  Input,
+  Text,
+  Box,
+} from '@chakra-ui/react';
+import { Link, useFetcher } from '@remix-run/react';
+import PropTypes from 'prop-types';
+import { useState, useEffect, useRef } from 'react';
+
+import useDebounce from '../hooks/useDebounce';
+
+const SearchModal = ({ isOpen, onClose }) => {
+  const [value, setValue] = useState('');
+  const fetcher = useFetcher();
+  const debouncedValue = useDebounce(value, 300);
+  const initialFocusRef = useRef();
+
+  useEffect(() => {
+    if (value.length > 2) {
+      const variables = { q: value };
+      fetcher.submit(variables, { action: '/search' });
+    }
+  }, [debouncedValue]);
+
+  const data = fetcher.data;
+
+  return (
+    <Modal initialFocusRef={initialFocusRef} isOpen={isOpen} onClose={onClose}>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Search</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          <fetcher.Form method="get" action="/search">
+            <Input
+              ref={initialFocusRef}
+              type="text"
+              name="q"
+              placeholder="Search..."
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              mb={2}
+            />
+          </fetcher.Form>
+          {data && (
+            <Box>
+              {data.error ? (
+                <Text>Failed to load results :(</Text>
+              ) : data.games.length || data.orgs.length || data.events.length ? (
+                <>
+                  {data.games.length > 0 && (
+                    <Box mb={2}>
+                      <Text fontWeight="bold" mb={1}>
+                        Games
+                      </Text>
+                      <List mb={2}>
+                        {data.games.map((game) => (
+                          <ListItem
+                            p={2}
+                            key={`game-${game.id}`}
+                            _hover={{ backgroundColor: 'gray.600', cursor: 'pointer' }}
+                            as={Link}
+                            to={`/game/${game.id}`}
+                            onClick={onClose}
+                          >
+                            {game.name}
+                          </ListItem>
+                        ))}
+                      </List>
+                    </Box>
+                  )}
+                  {data.orgs.length > 0 && (
+                    <Box mb={2}>
+                      <Text fontWeight="bold" mb={1}>
+                        Organizations
+                      </Text>
+                      <List mb={2}>
+                        {data.orgs.map((org) => (
+                          <ListItem
+                            p={2}
+                            key={`org-${org.id}`}
+                            _hover={{ backgroundColor: 'gray.600', cursor: 'pointer' }}
+                            as={Link}
+                            to={`/org/${org.id}`}
+                            onClick={onClose}
+                          >
+                            {org.name}
+                          </ListItem>
+                        ))}
+                      </List>
+                    </Box>
+                  )}
+                  {data.events.length > 0 && (
+                    <Box mb={2}>
+                      <Text fontWeight="bold" mb={1}>
+                        Events
+                      </Text>
+                      <List mb={2}>
+                        {data.events.map((event) => (
+                          <ListItem
+                            p={2}
+                            key={`event-${event.id}`}
+                            _hover={{ backgroundColor: 'gray.600', cursor: 'pointer' }}
+                            as={Link}
+                            to={`/event/${event.id}`}
+                            onClick={onClose}
+                          >
+                            {event.name}
+                          </ListItem>
+                        ))}
+                      </List>
+                    </Box>
+                  )}
+                </>
+              ) : (
+                <Text>No results has been found.</Text>
+              )}
+            </Box>
+          )}
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+SearchModal.defaultProps = {
+  isOpen: false,
+  onClose: () => {},
+};
+
+SearchModal.propTypes = {
+  isOpen: PropTypes.bool,
+  onClose: PropTypes.func,
+};
+
+export default SearchModal;


### PR DESCRIPTION
## Summary
- replace the inline search input with a button
- add `SearchModal` component that lists results from `/search`

## Testing
- `npm run build` *(fails: `remix` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cc7115e7c83308755a7e4bea773a6