### PR TITLE
feat: add add-menu dropdown to navigation

### DIFF
--- a/app/components/AddMenuButton.jsx
+++ b/app/components/AddMenuButton.jsx
@@ -1,0 +1,35 @@
+import {
+  Menu,
+  MenuButton,
+  MenuList,
+  MenuItem,
+  IconButton,
+} from '@chakra-ui/react';
+import { AddIcon } from '@chakra-ui/icons';
+import { Link } from '@remix-run/react';
+
+const AddMenuButton = () => (
+  <Menu>
+    <MenuButton
+      as={IconButton}
+      icon={<AddIcon w={6} h={6} />}
+      size="lg"
+      colorScheme="teal"
+      variant="solid"
+      aria-label="Add new"
+    />
+    <MenuList>
+      <MenuItem as={Link} to="/games/create">
+        Add game
+      </MenuItem>
+      <MenuItem as={Link} to="/events/create">
+        Add event
+      </MenuItem>
+      <MenuItem as={Link} to="/orgs/create">
+        Add organisation
+      </MenuItem>
+    </MenuList>
+  </Menu>
+);
+
+export default AddMenuButton;

--- a/app/components/Navigation.jsx
+++ b/app/components/Navigation.jsx
@@ -19,6 +19,7 @@ import { Link, useLoaderData, useLocation } from '@remix-run/react';
 import Logo from '../components/Logo';
 import AvatarButton from './AvatarButton';
 import SearchInput from './SearchInput';
+import AddMenuButton from './AddMenuButton';
 
 function NavLink(props) {
   const { href, ...rest } = props;
@@ -89,6 +90,8 @@ const Navigation = ({ search }) => {
           <Box flex="auto">
             <SearchInput defaultValue={search} />
           </Box>
+
+          {currentUser && <AddMenuButton />}
 
           <IconButton ml={2} icon={<HamburgerIcon />} onClick={onToggle} />
         </HStack>
@@ -172,6 +175,8 @@ const Navigation = ({ search }) => {
             </Box>
           )}
         </Box> */}
+
+        {currentUser && <AddMenuButton />}
 
         <AvatarButton />
       </HStack>


### PR DESCRIPTION
## Summary
- add AddMenuButton component with a dropdown for creating games, events, or organisations
- insert add-menu after search bar in navigation for mobile and desktop views

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bb19cb4ea48330a472d38ffb89eed0